### PR TITLE
[DNM] replace moment w/ date-fns

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,5 @@
     "test",
     "tests"
   ],
-  "dependencies": {
-    "moment": "^2.17.1"
-  }
+  "dependencies": {}
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      { pattern: 'bower_components/moment/min/moment.min.js', watched: false },
       'dist/opendata-chart-utils.js',
       'test/**/*.js'
     ],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {},
   "devDependencies": {
     "concurrently": "^3.4.0",
+    "date-fns": "^1.28.0",
     "karma": "^1.5.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-mocha-reporter": "^2.2.2",
@@ -22,6 +23,9 @@
     "qunitjs": "^2.1.1",
     "rollup": "^0.41.4",
     "rollup-plugin-buble": "^0.15.0",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-node-resolve": "^2.0.0",
+    "rollup-plugin-sizes": "^0.3.0",
     "semistandard": "^9.2.1",
     "watch": "^1.0.2"
   },

--- a/profiles/base.js
+++ b/profiles/base.js
@@ -1,4 +1,8 @@
+import commonjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
 import buble from 'rollup-plugin-buble';
+import sizes from 'rollup-plugin-sizes';
+
 const pkg = require('../package.json');
 const copyright = `/**
 * ${pkg.name} - v${pkg.version} - ${new Date().toString()}
@@ -10,6 +14,13 @@ export default {
   entry: 'src/index.js',
   moduleName: 'opendataChartUtils',
   format: 'umd',
-  plugins: [buble()],
+  plugins: [
+    resolve(),
+    commonjs({
+      include: 'node_modules/date-fns/**'
+    }),
+    buble(),
+    sizes()
+  ],
   banner: copyright
 };

--- a/src/date/get-periodic-time-interval.js
+++ b/src/date/get-periodic-time-interval.js
@@ -1,4 +1,8 @@
-/* global moment */
+import isDate from 'date-fns/is_date';
+import isAfter from 'date-fns/is_after';
+import differenceInSeconds from 'date-fns/difference_in_seconds';
+import differenceInMonths from 'date-fns/difference_in_months';
+
 /**
  * How to get Periodic time intervals
  *
@@ -7,49 +11,39 @@
   * @returns {string} or {null} - Returns type of time interval or null
  */
 export default function getPeriodicTimeInterval (startDate, endDate) {
-   // Make our start / ends be wrapped in moment for comparison logic
-  const start = moment(startDate);
-  const end = moment(endDate);
-
-  if (!shouldCalcDates(startDate, endDate)) { return null; }
-
-  if (calcDiffInDates(end, start, 'year') <= 25 && calcDiffInDates(end, start, 'month') > 12) {
-    return 'year';
-  } else if (calcDiffInDates(end, start, 'month') <= 12 && calcDiffInDates(end, start, 'day') > 31) {
-    return 'month';
-  } else if (calcDiffInDates(end, start, 'day') <= 31 && calcDiffInDates(end, start, 'hour') > 24) {
-    return 'day';
-  } else if (calcDiffInDates(end, start, 'hour') <= 24 && calcDiffInDates(end, start, 'minute') > 30) {
-    return 'hour';
-  } else if (calcDiffInDates(end, start, 'minute') <= 30 && calcDiffInDates(end, start, 'second') > 30) {
-    return 'minute';
-  } else if (calcDiffInDates(end, start, 'second') <= 30 && calcDiffInDates(end, start, 'second') > 1) {
-    return 'second';
-  }
-
-  return null;
-}
-
-// Determine the differences in dates. True is needed to calc as a float.
-function calcDiffInDates (end, start, measureOfTime) {
-  return end.diff(start, measureOfTime, true);
-}
-
-// Should we calc a time interval even?
-function shouldCalcDates (start, end) {
   // if either date is invalid return null
-  if (!validDate(start) || !validDate(end)) { return null; }
+  if (!isDate(startDate) || !isDate(endDate)) {
+    return null;
+  }
   // if the start date is after the end date return null
-  if (!startDateAfterEndDate(start, end)) { return null; }
-  return true;
-}
-
-// Is the date valid? new Date() because moment doesn't recognize datetime objects otherwise
-function validDate (date) {
-  return moment.isDate(new Date(date));
-}
-
-// Is the start date after the end date?
-function startDateAfterEndDate (start, end) {
-  return moment(start).isBefore(end);
+  if (isAfter(startDate, endDate)) {
+    return null;
+  }
+  const minute = 60;
+  const hour = minute * 60;
+  const day = hour * 24;
+  const year = 12;
+  const seconds = differenceInSeconds(endDate, startDate);
+  console.log('seconds', seconds);
+  if (seconds <= 1) {
+    return null;
+  }
+  if (seconds <= 30) {
+    return 'second';
+  } else if (seconds <= (30 * minute)) {
+    return 'minute';
+  } else if (seconds <= (24 * hour)) {
+    return 'hour';
+  } else if (seconds <= (29 * day)) {
+    return 'day';
+  } else {
+    const months = differenceInMonths(endDate, startDate);
+    if (months <= 12) {
+      return 'month';
+    } else if (months <= (25 * year)) {
+      return 'year';
+    } else {
+      return null;
+    }
+  }
 }

--- a/test/date/get-periodic-time-interval.js
+++ b/test/date/get-periodic-time-interval.js
@@ -4,6 +4,16 @@ QUnit.module('getPeriodicTimeInterval');
 // the year I didn't get what I wanted for xmas
 var startDate = new Date(1990, 11, 25);
 
+QUnit.test('getPeriodicTimeInterval returns null if start or end is not a date', function (assert) {
+  let result = opendataChartUtils.field.getPeriodicTimeInterval(startDate, 'test');
+  assert.equal(result, null);
+});
+
+QUnit.test('getPeriodicTimeInterval returns null if start date is after end date', function (assert) {
+  let result = opendataChartUtils.field.getPeriodicTimeInterval(startDate, new Date(1989, 11, 25, 0, 0, 0, 500));
+  assert.equal(result, null);
+});
+
 QUnit.test('getPeriodicTimeInterval returns year if > 12 months and <= 25 years', function (assert) {
   let result = opendataChartUtils.field.getPeriodicTimeInterval(startDate, new Date(2005, 11, 25));
   assert.equal(result, 'year');

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,7 +25,7 @@ acorn-object-spread@^1.0.0:
   dependencies:
     acorn "^3.1.0"
 
-acorn@4.0.4:
+acorn@4.0.4, acorn@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
@@ -252,6 +252,12 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+browser-resolve@^1.11.0:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  dependencies:
+    resolve "1.1.7"
+
 buble@^0.15.0:
   version "0.15.2"
   resolved "https://registry.yarnpkg.com/buble/-/buble-0.15.2.tgz#547fc47483f8e5e8176d82aa5ebccb183b02d613"
@@ -267,6 +273,10 @@ buble@^0.15.0:
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
+
+builtin-modules@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
 bytes@2.4.0:
   version "2.4.0"
@@ -300,7 +310,7 @@ chalk@0.5.1:
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
 
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -465,7 +475,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.23.0:
+date-fns@^1.23.0, date-fns@^1.28.0:
   version "1.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.0.tgz#3b12f54b66467807bb95e5930caf7bfb4170bc1a"
 
@@ -776,6 +786,10 @@ estree-walker@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
 
+estree-walker@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -863,6 +877,10 @@ file-entry-cache@^2.0.0:
 filename-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.0.tgz#996e3e80479b98b9897f15a8a58b3d084e926775"
+
+filesize@^3.3.0:
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.6.tgz#5fd98f3eac94ec9516ef8ed5782fad84a01a0a1a"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -1298,10 +1316,6 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-jasmine-core@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.5.2.tgz#6f61bd79061e27f43e6f9355e44b3c6cab6ff297"
-
 jodid25519@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
@@ -1370,9 +1384,15 @@ karma-chrome-launcher@^2.0.0:
     fs-access "^1.0.0"
     which "^1.2.1"
 
-karma-jasmine@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-1.1.0.tgz#22e4c06bf9a182e5294d1f705e3733811b810acf"
+karma-mocha-reporter@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/karma-mocha-reporter/-/karma-mocha-reporter-2.2.2.tgz#876de9a287244e54a608591732a98e66611f6abe"
+  dependencies:
+    chalk "1.1.3"
+
+karma-qunit@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/karma-qunit/-/karma-qunit-1.2.1.tgz#88252afd2127bc03b0cc31978ed6882b139f470a"
 
 karma-rollup-plugin@^0.2.4:
   version "0.2.4"
@@ -1425,6 +1445,18 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
+lodash.foreach@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.sumby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.sumby/-/lodash.sumby-4.6.0.tgz#7d87737ddb216da2f7e5e7cd2dd9c403a7887346"
+
 lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -1450,6 +1482,12 @@ magic-string@^0.14.0:
   dependencies:
     vlq "^0.2.1"
 
+magic-string@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.0.tgz#198948217254e3e0b93080e01146b7c73b2a06b2"
+  dependencies:
+    vlq "^0.2.1"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -1458,7 +1496,7 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
-micromatch@^2.1.5:
+micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -1509,6 +1547,10 @@ minimist@^1.1.0, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+module-details-from-path@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
 
 ms@0.7.1:
   version "0.7.1"
@@ -1743,6 +1785,10 @@ qs@6.3.1, qs@~6.3.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.1.tgz#918c0b3bcd36679772baf135b1acb4c1651ed79d"
 
+qunitjs@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.2.0.tgz#507db368305b6f45839b079195bca251ba76d50a"
+
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
@@ -1886,7 +1932,11 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@^1.1.6:
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.1.6, resolve@^1.1.7:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
   dependencies:
@@ -1918,12 +1968,47 @@ rollup-plugin-buble@^0.15.0:
     buble "^0.15.0"
     rollup-pluginutils "^1.5.0"
 
+rollup-plugin-commonjs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.0.2.tgz#98b1589bfe32a6c0f67790b60c0b499972afed89"
+  dependencies:
+    acorn "^4.0.1"
+    estree-walker "^0.3.0"
+    magic-string "^0.19.0"
+    resolve "^1.1.7"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-node-resolve@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-2.0.0.tgz#07e0ae94ac002a3ea36e8f33ca121d9f836b1309"
+  dependencies:
+    browser-resolve "^1.11.0"
+    builtin-modules "^1.1.0"
+    resolve "^1.1.6"
+
+rollup-plugin-sizes@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-sizes/-/rollup-plugin-sizes-0.3.0.tgz#fca8857489a500ca85c9d2c45c3560cc16f2d648"
+  dependencies:
+    filesize "^3.3.0"
+    lodash.assign "^4.2.0"
+    lodash.foreach "^4.5.0"
+    lodash.sumby "^4.6.0"
+    module-details-from-path "^1.0.3"
+
 rollup-pluginutils@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
+
+rollup-pluginutils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
 
 rollup@^0.41.4, rollup@^0.x:
   version "0.41.4"


### PR DESCRIPTION
Currently inlining date-fns using rollup plugins. 

Prob is that the source for the 3 functions we use from data-fns is 3x the size of the source of this repo:

```shell
> rollup -c profiles/dev.js

src/index.js:
date-fns - 15.48 KB (73.17%)
app - 4.97 KB (23.49%)
rollup helpers - 723 B (3.34%)
```

I'm sure a lot of that is comments, etc, b/c the final output is reasonable:

```shell
Destination: dist/opendata-chart-utils.min.js 
Bundle size: 4.41 KB, Gzipped size: 1.71 KB   
```

Not totally convinced this is a better approach than treating moment as an external - only makes sense if we can get rid of moment in OD, _and_ we don't end up using a whole bunch of date-fns in OD. Alternatively we could try to figure out how to use date-fns as an external.

