### PR TITLE
treat moment as an external instead of global

### DIFF
--- a/src/date/get-periodic-time-interval.js
+++ b/src/date/get-periodic-time-interval.js
@@ -1,4 +1,4 @@
-/* global moment */
+import moment from 'moment';
 /**
  * How to get Periodic time intervals
  *


### PR DESCRIPTION
When Rollup can't find moment it will treat it as an external.

This is the way it should have been in the first place.